### PR TITLE
Make code OS-independent

### DIFF
--- a/u2net_test.py
+++ b/u2net_test.py
@@ -37,7 +37,7 @@ def save_output(image_name,pred,d_dir):
     predict_np = predict.cpu().data.numpy()
 
     im = Image.fromarray(predict_np*255).convert('RGB')
-    img_name = image_name.split("/")[-1]
+    img_name = image_name.split(os.sep)[-1]
     image = io.imread(image_name)
     imo = im.resize((image.shape[1],image.shape[0]),resample=Image.BILINEAR)
 
@@ -57,11 +57,12 @@ def main():
     model_name='u2net'#u2netp
 
 
-    image_dir = './test_data/test_images/'
-    prediction_dir = './test_data/' + model_name + '_results/'
-    model_dir = './saved_models/'+ model_name + '/' + model_name + '.pth'
 
-    img_name_list = glob.glob(image_dir + '*')
+    image_dir = os.path.join(os.getcwd(), 'test_data', 'test_images')
+    prediction_dir = os.path.join(os.getcwd(), 'test_data', model_name + '_results' + os.sep)
+    model_dir = os.path.join(os.getcwd(), 'saved_models', model_name, model_name + '.pth')
+
+    img_name_list = glob.glob(image_dir + os.sep + '*')
     print(img_name_list)
 
     # --------- 2. dataloader ---------
@@ -91,7 +92,7 @@ def main():
     # --------- 4. inference for each image ---------
     for i_test, data_test in enumerate(test_salobj_dataloader):
 
-        print("inferencing:",img_name_list[i_test].split("/")[-1])
+        print("inferencing:",img_name_list[i_test].split(os.sep)[-1])
 
         inputs_test = data_test['image']
         inputs_test = inputs_test.type(torch.FloatTensor)
@@ -108,6 +109,8 @@ def main():
         pred = normPRED(pred)
 
         # save results to test_results folder
+        if not os.path.exists(prediction_dir):
+            os.makedirs(prediction_dir, exist_ok=True)
         save_output(img_name_list[i_test],pred,prediction_dir)
 
         del d1,d2,d3,d4,d5,d6,d7

--- a/u2net_train.py
+++ b/u2net_train.py
@@ -46,14 +46,14 @@ def muti_bce_loss_fusion(d0, d1, d2, d3, d4, d5, d6, labels_v):
 
 model_name = 'u2net' #'u2netp'
 
-data_dir = './train_data/'
-tra_image_dir = 'DUTS/DUTS-TR/DUTS-TR/im_aug/'
-tra_label_dir = 'DUTS/DUTS-TR/DUTS-TR/gt_aug/'
+data_dir = os.path.join(os.getcwd(), 'train_data' + os.sep)
+tra_image_dir = os.path.join('DUTS', 'DUTS-TR', 'DUTS-TR', 'im_aug' + os.sep)
+tra_label_dir = os.path.join('DUTS', 'DUTS-TR', 'DUTS-TR', 'gt_aug' + os.sep)
 
 image_ext = '.jpg'
 label_ext = '.png'
 
-model_dir = './saved_models/' + model_name +'/'
+model_dir = os.path.join(os.getcwd(), 'saved_models', model_name + os.sep)
 
 epoch_num = 100000
 batch_size_train = 12
@@ -65,7 +65,7 @@ tra_img_name_list = glob.glob(data_dir + tra_image_dir + '*' + image_ext)
 
 tra_lbl_name_list = []
 for img_path in tra_img_name_list:
-	img_name = img_path.split("/")[-1]
+	img_name = img_path.split(os.sep)[-1]
 
 	aaa = img_name.split(".")
 	bbb = aaa[0:-1]


### PR DESCRIPTION
Thanks for the code!

Due to the present case of the pandemic, I am unable to access my work computer that has Ubuntu, leaving me with a laptop with Windows installed. The changes I've introduced simply make the code OS-independent so that anyone can train their model or make inferences in the provided models, no matter what OS they may have installed.

I have successfully run trials with the modified `u2net_test.py` file, both in the provided images, as well with my own, whilst using both provided models. However, I have yet to try the modified `u2net_train.py` code, as both my laptop GPU won't be able to handle it as well as I don't have the necessary training data to perform this.