### PR TITLE
bug fix: separator character was not correct on windows environment.

### DIFF
--- a/u2net_portrait_demo.py
+++ b/u2net_portrait_demo.py
@@ -169,7 +169,7 @@ def main():
         im_portrait = inference(net,im_face)
 
         # save the output
-        cv2.imwrite(out_dir+"/"+im_list[i].split('/')[-1][0:-4]+'.png',(im_portrait*255).astype(np.uint8))
+        cv2.imwrite(os.path.join(out_dir,im_list[i].split(os.sep)[-1][0:-4]+'.png'),(im_portrait*255).astype(np.uint8))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
[Problem]
The path separator charactor '/' will be changed on windows environment such as '\\'.
As a result of this, Nothing output will produce.

[Solution]
Use os.sep value for separate charactor.